### PR TITLE
Fix scaffold generation

### DIFF
--- a/lib/angus/generator/templates/definitions/operations.yml.erb
+++ b/lib/angus/generator/templates/definitions/operations.yml.erb
@@ -17,8 +17,10 @@
       required: <%= response_required(action_name) %>
       type: <%= response_type(action_name) %>
 
+  <% if is_demo? %>
   messages:
     - key: <%= message_key(action_name) %>
       description: '<%= message_description(action_name) %>'
+  <% end %>
 <% end %>
 <% end %>

--- a/lib/angus/generator/thor/resource.rb
+++ b/lib/angus/generator/thor/resource.rb
@@ -11,7 +11,7 @@ class Thor
     #
     # @example
     #
-    #   resource 'user', 'resouces', 'definitions'
+    #   resource 'user', 'resources', 'definitions'
     #
     def resource(name, actions, config = {})
       action Resource.new(self, name, actions, config)


### PR DESCRIPTION
Right now we don't have messages to show on the operations, so the scaffold leave them in blank, and that causes an error when we try to start the app.
