### PR TITLE
Fixed the documentation url to go to rubydoc

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <header itemscope="" itemtype="http://schema.org/Organization" class="Header">
       <div class="Header-wrapper"><a href="/" class="Header-logo"><img src="images/angus_logo.svg"></a>
         <nav class="Navbar">
-          <div class="Navbar-doc"><a href="https://github.com/Moove-it/angus" target="_blank">docs</a>
+          <div class="Navbar-doc"><a href="http://www.rubydoc.info/github/moove-it/angus" target="_blank">docs</a>
           </div>
           <ul class="Navbar-list">
                 <li class="Navbar-listItem benchmark-index"><a href="#benchmark">benchmark</a>
@@ -23,7 +23,7 @@
                 </li>
                 <li class="Navbar-listItem tools-index"><a href="#tools">tools</a>
                 </li>
-                <li class="Navbar-listItem docs-index Navbar-listItem--doc"><a href="https://github.com/Moove-it/angus" target="_blank">docs</a>
+                <li class="Navbar-listItem docs-index Navbar-listItem--doc"><a href="http://www.rubydoc.info/github/moove-it/angus" target="_blank">docs</a>
                 </li>
           </ul>
         </nav>


### PR DESCRIPTION
The documentation url was pointed to github instead of rubydoc.