### PR TITLE
Fix angus sdoc definitions build

### DIFF
--- a/lib/angus/resource_definition.rb
+++ b/lib/angus/resource_definition.rb
@@ -73,7 +73,7 @@ module Angus
           field_name.to_sym
         else
           if parent_name
-            parent_name.concat(".#{field_name}")
+            parent_name += ".#{field_name}"
           else
             parent_name = field_name
           end


### PR DESCRIPTION
Fixed error on building when the representation is an angus sdoc representation